### PR TITLE
Add support for initializing Sleigh directly from sla file contents

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,7 +146,7 @@ dependencies = [
 
 [[package]]
 name = "libsla-sys"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "cxx",
  "cxx-build",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libsla-sys"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2024"
 description = "System crate for Ghidra Sleigh library libsla"
 categories = ["security", "external-ffi-bindings"]

--- a/src/cpp/bridge.cc
+++ b/src/cpp/bridge.cc
@@ -155,6 +155,26 @@ std::unique_ptr<std::vector<RegisterVarnodeName>> SleighProxy::getAllRegistersPr
     return reglist;
 }
 
+void SleighProxy::initializeFromSla(const std::string &sla) {
+    std::stringstream slaStream(sla);
+
+    // This is based on the code in Sleigh::initialize
+    if (!isInitialized()) {
+        sla::FormatDecode decoder(this);
+        decoder.ingestStream(slaStream);
+        decode(decoder);
+    }
+
+  if (isInitialized()) {
+      // Dummy store, will not be accessed if initialized.
+      // Still need to call Sleigh::initialize to finish initialization
+      DocumentStorage store;
+      initialize(store);
+  } else {
+      throw LowlevelError("Failed to initialize sleigh");
+  }
+}
+
 int4 SleighProxy::disassemblePcode(const RustLoadImage &loadImage, RustPcodeEmit &emit, const Address &baseaddr) const {
     // The loader is stored in the loader proxy only for as long as this manager lives
     RustLoadImageManager manager { *loader.get(), loadImage };

--- a/src/cpp/bridge.hh
+++ b/src/cpp/bridge.hh
@@ -77,6 +77,7 @@ class SleighProxy : public Sleigh {
         int4 disassembleNative(const RustLoadImage &loadImage, RustAssemblyEmit &emit, const Address &baseaddr) const;
         std::unique_ptr<std::string> getRegisterNameProxy(AddrSpace *base, uintb off, int4 size) const;
         unique_ptr<vector<RegisterVarnodeName>> getAllRegistersProxy() const;
+        void initializeFromSla(const std::string &sla);
 };
 
 unique_ptr<SleighProxy> construct_new_sleigh(unique_ptr<ContextDatabase> context);

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -315,6 +315,8 @@ mod default {
         #[rust_name = "new_sleigh"]
         fn construct_new_sleigh(context: UniquePtr<ContextDatabase>) -> UniquePtr<SleighProxy>;
         fn initialize(self: Pin<&mut SleighProxy>, store: Pin<&mut DocumentStorage>) -> Result<()>;
+        #[rust_name = "initialize_from_sla"]
+        fn initializeFromSla(self: Pin<&mut SleighProxy>, sla: &CxxString) -> Result<()>;
         #[rust_name = "num_spaces"]
         fn numSpaces(self: &SleighProxy) -> i32;
         #[rust_name = "address_space"]


### PR DESCRIPTION
This change adds a new method to support initializing Sleigh directly from the sla file contents.

This is a slight modification to the standard Sleigh initialization, which as of Ghidra 11.1 would parse an XML file to obtain the sla file path, read the sla file, and then initialize. With this change, the sla specification no longer needs to exist as a file on disk.