### PR TITLE
Using namespace std in bridge code is incorrectly placed

### DIFF
--- a/src/cpp/bridge.hh
+++ b/src/cpp/bridge.hh
@@ -1,7 +1,5 @@
 #pragma once
 
-using namespace std;
-
 #include <memory>
 
 #include "error_handling.hh"
@@ -11,6 +9,7 @@ using namespace std;
 #include "translate.hh"
 #include "marshal.hh"
 
+using namespace std;
 using namespace ghidra;
 
 class RustAssemblyEmit;


### PR DESCRIPTION
The `using namespace std` should be after includes, otherwise the `std` namespace is not defined.