### PR TITLE
Add support for building with fuzzing instrumentation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,7 +146,7 @@ dependencies = [
 
 [[package]]
 name = "libsla-sys"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "cxx",
  "cxx-build",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,17 @@ include = [
     "/ghidra/licenses/*",
 ]
 
+[features]
+
+# Must be defined as the RUSTC_LINKER
+clang = []
+
+# Must build with rustc nightly flag -Z sanitizer=address
+asan = ["clang"]
+ubsan = ["clang"]
+sancov = ["clang"]
+fuzzing = ["asan", "ubsan", "sancov"]
+
 [dependencies]
 cxx = "1.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libsla-sys"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2024"
 description = "System crate for Ghidra Sleigh library libsla"
 categories = ["security", "external-ffi-bindings"]
@@ -22,7 +22,7 @@ include = [
 
 [features]
 
-# Must be defined as the RUSTC_LINKER
+# Must either be the default linker or defined as the RUSTC_LINKER
 clang = []
 
 # Must build with rustc nightly flag -Z sanitizer=address


### PR DESCRIPTION
This adds support for the following feature flags:

* `clang` whose path must be defined via the rustc linker flag.
* `asan` which enables Address Sanitizer. Requires `clang`.
* `ubsan` which enables Undefined Behavior Sanitizer. Requires `clang`.
* `sancov` which enables Sanitizer Coverage for use with fuzzer drivers like libFuzzer. Requires `clang`.
* `fuzzing` which enables `asan`, `ubsan` and `sancov`.