### PR TITLE
 Add initialize_from_raw_sla

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,7 +146,7 @@ dependencies = [
 
 [[package]]
 name = "libsla-sys"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "cxx",
  "cxx-build",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libsla-sys"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2024"
 description = "System crate for Ghidra Sleigh library libsla"
 categories = ["security", "external-ffi-bindings"]

--- a/src/cpp/bridge.cc
+++ b/src/cpp/bridge.cc
@@ -222,7 +222,6 @@ RustLoadImageManager::~RustLoadImageManager() {
 
 const int4 RawFormatDecode::IN_BUFFER_SIZE = 4096;
 
-/// \param spcManager is the (uninitialized) manager that will hold decoded address spaces
 RawFormatDecode::RawFormatDecode(const AddrSpaceManager *spcManager)
   : PackedDecode(spcManager)
 {

--- a/src/cpp/bridge.cc
+++ b/src/cpp/bridge.cc
@@ -165,14 +165,34 @@ void SleighProxy::initializeFromSla(const std::string &sla) {
         decode(decoder);
     }
 
-  if (isInitialized()) {
-      // Dummy store, will not be accessed if initialized.
-      // Still need to call Sleigh::initialize to finish initialization
-      DocumentStorage store;
-      initialize(store);
-  } else {
-      throw LowlevelError("Failed to initialize sleigh");
-  }
+    if (isInitialized()) {
+        // Dummy store, will not be accessed if initialized.
+        // Still need to call Sleigh::initialize to finish initialization
+        DocumentStorage store;
+        initialize(store);
+    } else {
+        throw LowlevelError("Failed to initialize sleigh");
+    }
+}
+
+void SleighProxy::initializeFromRawSla(const std::string &sla) {
+    std::stringstream slaStream(sla);
+
+    // This is based on the code in Sleigh::initialize
+    if (!isInitialized()) {
+        RawFormatDecode decoder(this);
+        decoder.ingestStream(slaStream);
+        decode(decoder);
+    }
+
+    if (isInitialized()) {
+        // Dummy store, will not be accessed if initialized.
+        // Still need to call Sleigh::initialize to finish initialization
+        DocumentStorage store;
+        initialize(store);
+    } else {
+        throw LowlevelError("Failed to initialize sleigh");
+    }
 }
 
 int4 SleighProxy::disassemblePcode(const RustLoadImage &loadImage, RustPcodeEmit &emit, const Address &baseaddr) const {
@@ -198,4 +218,42 @@ RustLoadImageManager::RustLoadImageManager(RustLoadImageProxy &proxy, const Rust
 
 RustLoadImageManager::~RustLoadImageManager() {
     this->proxy.resetInner();
+}
+
+const int4 RawFormatDecode::IN_BUFFER_SIZE = 4096;
+
+/// \param spcManager is the (uninitialized) manager that will hold decoded address spaces
+RawFormatDecode::RawFormatDecode(const AddrSpaceManager *spcManager)
+  : PackedDecode(spcManager)
+{
+    inBuffer = new uint1[IN_BUFFER_SIZE];
+}
+
+RawFormatDecode::~RawFormatDecode(void) {
+    delete[] inBuffer;
+}
+
+
+void RawFormatDecode::ingestStream(istream &s) {
+    uint1 *outBuf;
+    int4 outAvail = 0;
+    while (true) {
+        s.read((char *)inBuffer,IN_BUFFER_SIZE);
+        int4 gcount = s.gcount();
+        if (gcount == 0)
+            break;
+        int4 inAvail = gcount;
+        do {
+            if (outAvail == 0) {
+                outBuf = allocateNextInputBuffer(0);
+                outAvail = BUFFER_SIZE;
+            }
+            int4 copySize = std::min(outAvail, inAvail);
+            memcpy(outBuf + (BUFFER_SIZE - outAvail), inBuffer + (gcount - inAvail), copySize);
+            outAvail -= copySize;
+            inAvail -= copySize;
+        } while(outAvail == 0);
+    }
+
+    endIngest(BUFFER_SIZE - outAvail);
 }

--- a/src/cpp/bridge.hh
+++ b/src/cpp/bridge.hh
@@ -65,6 +65,15 @@ class RegisterVarnodeName {
         const std::string& getName() const;
 };
 
+class RawFormatDecode : public PackedDecode {
+  static const int4 IN_BUFFER_SIZE;
+  uint1 *inBuffer;
+public:
+  RawFormatDecode(const AddrSpaceManager *spcManager);
+  virtual ~RawFormatDecode();
+  virtual void ingestStream(istream &s);
+};
+
 class SleighProxy : public Sleigh {
     unique_ptr<RustLoadImageProxy> loader;
     unique_ptr<ContextDatabase> context;
@@ -77,6 +86,7 @@ class SleighProxy : public Sleigh {
         std::unique_ptr<std::string> getRegisterNameProxy(AddrSpace *base, uintb off, int4 size) const;
         unique_ptr<vector<RegisterVarnodeName>> getAllRegistersProxy() const;
         void initializeFromSla(const std::string &sla);
+        void initializeFromRawSla(const std::string &sla);
 };
 
 unique_ptr<SleighProxy> construct_new_sleigh(unique_ptr<ContextDatabase> context);

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -317,6 +317,8 @@ mod default {
         fn initialize(self: Pin<&mut SleighProxy>, store: Pin<&mut DocumentStorage>) -> Result<()>;
         #[rust_name = "initialize_from_sla"]
         fn initializeFromSla(self: Pin<&mut SleighProxy>, sla: &CxxString) -> Result<()>;
+        #[rust_name = "initialize_from_raw_sla"]
+        fn initializeFromRawSla(self: Pin<&mut SleighProxy>, sla: &CxxString) -> Result<()>;
         #[rust_name = "num_spaces"]
         fn numSpaces(self: &SleighProxy) -> i32;
         #[rust_name = "address_space"]


### PR DESCRIPTION
This adds the ability to build the sleigh object using the raw sla format. The standard sla format includes a 4-byte header: `0x73 0x6c 0x61 0x04`. The first 3 bytes are the characters `sla`, and the last byte is the format version number (currently 4). The remaining bytes are the sla data, which are zlib-compresed.

The raw sla format does not include the header and does not compress the data. One use for this format is for fuzzing. It is possible to build a fuzzer that compresses the generated input to ensure it decompresses successfully, but this needless roundtrip will substantially slow down the fuzzer.