### PR TITLE
Update build to use C++11 for compatibility with Ghidra

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -146,7 +146,7 @@ dependencies = [
 
 [[package]]
 name = "libsla-sys"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "cxx",
  "cxx-build",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libsla-sys"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2024"
 description = "System crate for Ghidra Sleigh library libsla"
 categories = ["security", "external-ffi-bindings"]

--- a/build.rs
+++ b/build.rs
@@ -60,7 +60,7 @@ fn main() {
     build
         .define("LOCAL_ZLIB", "1")
         .define("NO_GZIP", "1")
-        .flag_if_supported("-std=c++14");
+        .flag_if_supported("-std=c++11");
 
     if std::env::var("CARGO_FEATURE_SANCOV").is_ok() {
         build.flag("-fsanitize-coverage=inline-8bit-counters");

--- a/src/cpp/bridge.cc
+++ b/src/cpp/bridge.cc
@@ -66,12 +66,12 @@ SleighProxy::SleighProxy(unique_ptr<RustLoadImageProxy> loader, unique_ptr<Conte
 }
 
 unique_ptr<SleighProxy> construct_new_sleigh(unique_ptr<ContextDatabase> context) {
-    auto loader = make_unique<RustLoadImageProxy>();
-    return make_unique<SleighProxy>(move(loader), move(context));
+    auto loader = std::unique_ptr<RustLoadImageProxy>(new RustLoadImageProxy());
+    return std::unique_ptr<SleighProxy>(new SleighProxy(move(loader), move(context)));
 }
 
 unique_ptr<ContextDatabase> construct_new_context() {
-    return make_unique<ContextInternal>();
+    return std::unique_ptr<ContextDatabase>(new ContextInternal());
 }
 
 RustPcodeEmitProxy::RustPcodeEmitProxy(RustPcodeEmit &emit)
@@ -87,7 +87,7 @@ void initialize_attribute_id() {
 }
 
 unique_ptr<Address> getAddress(const VarnodeData &data) {
-    return make_unique<Address>(data.space, data.offset);
+    return std::unique_ptr<Address>(new Address(data.space, data.offset));
 }
 
 uint4 getSize(const VarnodeData &data) {
@@ -139,7 +139,7 @@ void SleighProxy::parseProcessorConfig(const DocumentStorage &store) {
 }
 
 std::unique_ptr<std::string> SleighProxy::getRegisterNameProxy(AddrSpace *base, uintb off, int4 size) const {
-    return std::make_unique<std::string>(getRegisterName(base, off, size));
+    return std::unique_ptr<std::string>(new std::string(getRegisterName(base, off, size)));
 }
 
 
@@ -147,7 +147,7 @@ std::unique_ptr<std::vector<RegisterVarnodeName>> SleighProxy::getAllRegistersPr
     std::map<VarnodeData, std::string> regmap;
     getAllRegisters(regmap);
 
-    auto reglist = std::make_unique<std::vector<RegisterVarnodeName>>();
+    auto reglist = std::unique_ptr<std::vector<RegisterVarnodeName>>(new std::vector<RegisterVarnodeName>());
     for (auto &regmapEntry : regmap) {
         reglist->push_back(RegisterVarnodeName(regmapEntry));
     }

--- a/src/cpp/bridge.hh
+++ b/src/cpp/bridge.hh
@@ -99,7 +99,7 @@ T construct(Args... args) {
 
 template<typename T, typename... Args>
 unique_ptr<T> construct_new(Args... args) {
-    return make_unique<T>(args...);
+    return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
 }
 
 void initialize_element_id();


### PR DESCRIPTION
Ghidra builds its decompiler, of which libsla is a component, using C++11. So far building with C++14 has worked but there's no reason to be out-of-sync with Ghidra. This has caused complications when submitting Ghidra patches since e.g. `std::make_unique` isn't available in C++11, but the patches work under this library.